### PR TITLE
fix error loading rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed error where rows would never be loaded if no custom config was set
 
 ## [1.5.5] - 2020-06-18
 

--- a/projects/smart-table/src/lib/smart-table/smart-table.component.ts
+++ b/projects/smart-table/src/lib/smart-table/smart-table.component.ts
@@ -19,7 +19,7 @@ import {
   SmartTableFilterType,
   UpdateFilterArgs,
 } from './smart-table.types';
-import {catchError, filter, first, map, shareReplay, startWith, switchMap, take, takeUntil, tap, skip} from 'rxjs/operators';
+import {catchError, filter, first, map, shareReplay, startWith, switchMap, take, takeUntil, tap, skip, debounceTime} from 'rxjs/operators';
 import {PROVIDE_ID} from '../indentifier.provider';
 import {BehaviorSubject, combineLatest, concat, merge, Observable, of, Subject} from 'rxjs';
 import {TableFactory} from '../services/table.factory';
@@ -324,7 +324,8 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       this.currentPage$
     ).pipe(
       // during initial configuration several values get pushed
-      skip(7),
+      // cannot skip because the number of skips varies depending on config
+      debounceTime(10),
       tap(() => this.pageChanging = !this.rowsLoading),
       switchMap(([dataQuery, pageSize, page]) =>
         this.dataService.getData(this.apiUrl, this.httpHeaders, dataQuery, page, pageSize)),

--- a/projects/smart-table/src/lib/smart-table/smart-table.component.ts
+++ b/projects/smart-table/src/lib/smart-table/smart-table.component.ts
@@ -325,7 +325,6 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       this.pageSize$,
       this.currentPage$
     ).pipe(
-      skip(1),  // Skip initial value since configuration will come in
       auditTime(100),  // Skip initial time based values, don't reset the timer after new values come in
       tap(() => this.pageChanging = !this.rowsLoading),
       switchMap(([dataQuery, pageSize, page]) =>

--- a/projects/smart-table/src/lib/smart-table/smart-table.component.ts
+++ b/projects/smart-table/src/lib/smart-table/smart-table.component.ts
@@ -19,7 +19,7 @@ import {
   SmartTableFilterType,
   UpdateFilterArgs,
 } from './smart-table.types';
-import {catchError, filter, first, map, shareReplay, startWith, switchMap, take, takeUntil, tap, skip, debounceTime} from 'rxjs/operators';
+import {auditTime, catchError, filter, first, map, shareReplay, skip, startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {PROVIDE_ID} from '../indentifier.provider';
 import {BehaviorSubject, combineLatest, concat, merge, Observable, of, Subject} from 'rxjs';
 import {TableFactory} from '../services/table.factory';
@@ -200,6 +200,7 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       )
     ).pipe(
       map((columns: Array<TableColumn>) => columns.filter(c => !!c && !c.hidden)),
+      shareReplay(1)
     );
 
     /**
@@ -287,6 +288,7 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       this.configuration$,
       this.orderBy$
     ).pipe(
+      skip(5),  // The values are shared replayed, so skip the 5 initial emits of the observables
       map(([visibleFilters, optionalFilters, genericFilter, configuration, orderBy]:
              [SmartTableFilter[], SmartTableFilter[], SmartTableFilter, SmartTableConfig, OrderBy]) => {
         const filters = [
@@ -323,9 +325,8 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       this.pageSize$,
       this.currentPage$
     ).pipe(
-      // during initial configuration several values get pushed
-      // cannot skip because the number of skips varies depending on config
-      debounceTime(10),
+      skip(1),  // Skip initial value since configuration will come in
+      auditTime(100),  // Skip initial time based values, don't reset the timer after new values come in
       tap(() => this.pageChanging = !this.rowsLoading),
       switchMap(([dataQuery, pageSize, page]) =>
         this.dataService.getData(this.apiUrl, this.httpHeaders, dataQuery, page, pageSize)),


### PR DESCRIPTION
Verschillende van de observables emitten meerdere waardes tijdens bootstrap, en het aantal waardes verschilt naargelang van hoe de smart table geconfigureerd is. Hierdoor breekt de smart table in de OVGB app. Omwille van het variabele aantal emitted values is skip(X) dus geen optie. Ik heb even gekeken of het aantal emitted values gereduceerd kan worden zonder debounceTime te gebruiken, bvb met een skipWhile of skipUntil, maar vond niet meteen een goeie manier buiten diepe refactoring. Daarom deze quick fix.