### PR TITLE
Lowered the value of skip when listening to the dataQuery$ observable.

### DIFF
--- a/projects/smart-table/src/lib/smart-table/smart-table.component.ts
+++ b/projects/smart-table/src/lib/smart-table/smart-table.component.ts
@@ -288,7 +288,7 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       this.configuration$,
       this.orderBy$
     ).pipe(
-      skip(5),  // The values are shared replayed, so skip the 5 initial emits of the observables
+      skip(3),  // The values are shared replayed, so skip the 3 initial emits of the observables
       map(([visibleFilters, optionalFilters, genericFilter, configuration, orderBy]:
              [SmartTableFilter[], SmartTableFilter[], SmartTableFilter, SmartTableConfig, OrderBy]) => {
         const filters = [


### PR DESCRIPTION
Lowered the value of skip when listening to the dataQuery$ observable,
because changes to the baseFilters in the customConfiguration 
were ignored when changed in ngOnInit of another component.