### PR TITLE
Fixed issue with sorting and filtering

### DIFF
--- a/projects/example-api/api.js
+++ b/projects/example-api/api.js
@@ -136,6 +136,9 @@ app.listen(port, () => console.log(`Example app listening on port ${port}!`));
 
 function getDataFromRequest(req) {
   const body = req.body || {};
+  console.log("-------------------------------", (new Date()).toISOString());
+  console.log(req.body);
+  console.log("-------------------------------");
 
   let response = movies.slice();
 

--- a/projects/example/src/app/app.component.ts
+++ b/projects/example/src/app/app.component.ts
@@ -31,7 +31,7 @@ export class AppComponent {
         export: 'Exporteer',
         apply: 'Toepassen',
       },
-      resetSortOrderOnFilter: false
+      resetSortOrderOnFilter: true
     }
   };
 

--- a/projects/smart-table/src/lib/components/smart-table/smart-table.component.ts
+++ b/projects/smart-table/src/lib/components/smart-table/smart-table.component.ts
@@ -21,16 +21,16 @@ import {
   catchError,
   distinctUntilChanged,
   filter,
-  first,
+  first, last,
   map,
   scan,
   share,
   shareReplay,
   skip,
   startWith,
-  switchMap,
+  switchMap, take,
   takeUntil,
-  tap
+  tap, withLatestFrom
 } from 'rxjs/operators';
 import {BehaviorSubject, combineLatest, merge, Observable, of, Subject} from 'rxjs';
 import {TableFactory} from '../../services/table.factory';
@@ -106,6 +106,9 @@ export class SmartTableComponent implements OnInit, OnDestroy {
   public rows$: Observable<Array<any>>;
   public error$: Observable<HttpErrorResponse>;
 
+  private initialConfiguration;
+  private filters;
+
   /** @internal */
   orderBy$: Observable<OrderBy>;
   /** @internal */
@@ -175,6 +178,9 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       storageCallback: (config) => of(this.storageService.getConfiguration(config)),
     });
     this.configuration$ = this.configurationService.getConfiguration(this.instanceId);
+    this.configuration$.pipe(take(2), tap(config => {
+      this.initialConfiguration = config;
+    })).subscribe();
     this.configuration$.pipe(
       takeUntil(this.destroy$),
       distinctUntilChanged(),
@@ -238,13 +244,8 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       share(),
     );
 
-    this.orderBy$ = combineLatest([
-      this.onFilterChanged$.pipe(startWith(undefined)),
-      this.configuration$
-    ]).pipe(
-      filter(([filterChanged, configuration]: [SmartTableFilter, SmartTableConfig]) =>
-        !!filterChanged ? configuration.options && configuration.options.resetSortOrderOnFilter === true : true),
-      map(values => values[1]),
+    // let lastFilter;
+    this.orderBy$ = this.configuration$.pipe(
       map(config => (config && config.options && config.options.defaultSortOrder) || SMARTTABLE_DEFAULT_OPTIONS.defaultSortOrder),
     );
     /**
@@ -254,6 +255,9 @@ export class SmartTableComponent implements OnInit, OnDestroy {
      */
     this.activeFilters$ = this.onFilterChanged$.pipe(
       takeUntil(this.destroy$),
+      tap(filters => {
+        this.filters = filters;
+      }),
       scan((accumulator: SmartTableFilter[], update: UpdateFilterArgs) => {
         const index = accumulator.findIndex(f => f.id === update.filter.id);
         if (index < 0 && !!update.value && !!update.value.length) {
@@ -265,7 +269,23 @@ export class SmartTableComponent implements OnInit, OnDestroy {
         }
         return accumulator;
       }, []),
-      tap(filters => this.filter.next(filters)),
+      withLatestFrom(this.configuration$),
+      tap(([filters, config]) => {
+          if (config.options && config.options.resetSortOrderOnFilter === true) {
+            // reset sortOrder
+            config = {
+              ...config,
+              options: {
+                ...config.options,
+                defaultSortOrder: this.initialConfiguration.options.defaultSortOrder
+              },
+              filters: this.filters || config.filters
+            };
+            this.configurationService.setConfiguration(this.instanceId, config);
+          }
+          this.filter.next(filters);
+      }),
+      map(values => values[0]),
       startWith([])
     );
     // Build up the data query based on the different filters
@@ -366,7 +386,8 @@ export class SmartTableComponent implements OnInit, OnDestroy {
         options: {
           ...config.options,
           defaultSortOrder: orderBy
-        }
+        },
+        filters: this.filters || config.filters
       })),
       tap(configuration => this.configurationService.setConfiguration(this.instanceId, configuration))
     ).subscribe();

--- a/projects/smart-table/src/lib/components/smart-table/smart-table.component.ts
+++ b/projects/smart-table/src/lib/components/smart-table/smart-table.component.ts
@@ -178,7 +178,7 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       storageCallback: (config) => of(this.storageService.getConfiguration(config)),
     });
     this.configuration$ = this.configurationService.getConfiguration(this.instanceId);
-    this.configuration$.pipe(take(2), tap(config => {
+    this.configuration$.pipe(take(2), skip(1), tap(config => {
       this.initialConfiguration = config;
     })).subscribe();
     this.configuration$.pipe(

--- a/projects/smart-table/src/lib/components/smart-table/smart-table.component.ts
+++ b/projects/smart-table/src/lib/components/smart-table/smart-table.component.ts
@@ -21,16 +21,18 @@ import {
   catchError,
   distinctUntilChanged,
   filter,
-  first, last,
+  first,
   map,
   scan,
   share,
   shareReplay,
   skip,
   startWith,
-  switchMap, take,
+  switchMap,
+  take,
   takeUntil,
-  tap, withLatestFrom
+  tap,
+  withLatestFrom
 } from 'rxjs/operators';
 import {BehaviorSubject, combineLatest, merge, Observable, of, Subject} from 'rxjs';
 import {TableFactory} from '../../services/table.factory';
@@ -178,9 +180,13 @@ export class SmartTableComponent implements OnInit, OnDestroy {
       storageCallback: (config) => of(this.storageService.getConfiguration(config)),
     });
     this.configuration$ = this.configurationService.getConfiguration(this.instanceId);
-    this.configuration$.pipe(take(2), skip(1), tap(config => {
-      this.initialConfiguration = config;
-    })).subscribe();
+    this.configuration$.pipe(
+      take(2),
+      skip(1),
+      tap(config => {
+        this.initialConfiguration = config;
+      })
+    ).subscribe();
     this.configuration$.pipe(
       takeUntil(this.destroy$),
       distinctUntilChanged(),
@@ -284,7 +290,7 @@ export class SmartTableComponent implements OnInit, OnDestroy {
         return accumulator;
       }, []),
       tap(filters => {
-          this.filter.next(filters);
+        this.filter.next(filters);
       }),
       startWith([])
     );

--- a/projects/smart-table/src/lib/services/api.service.ts
+++ b/projects/smart-table/src/lib/services/api.service.ts
@@ -65,6 +65,7 @@ export class ApiService {
   public getData(
     apiUrl: string, headers: HttpHeaders, dataQuery: SmartTableDataQuery, page?: number, pageSize?: number
   ): Observable<any> {
+    console.log("Dataquery: ", dataQuery);
     if (!headers) {
       headers = new HttpHeaders();
     }

--- a/projects/smart-table/src/lib/services/api.service.ts
+++ b/projects/smart-table/src/lib/services/api.service.ts
@@ -65,7 +65,6 @@ export class ApiService {
   public getData(
     apiUrl: string, headers: HttpHeaders, dataQuery: SmartTableDataQuery, page?: number, pageSize?: number
   ): Observable<any> {
-    console.log("Dataquery: ", dataQuery);
     if (!headers) {
       headers = new HttpHeaders();
     }


### PR DESCRIPTION
Er zijn 2 problemen met de combinatie van sorteren en filteren.

- Als er een filter actief is, en je sorteert daarna, dan wordt de filter visueel gereset ondanks dat hij wel nog actief blijft
- Als je filtert en je sorteert daarna dan wordt de kolom header visueel aangepast, maar de sortering wordt niet toegepast