### PR TITLE
Fix SOP issues with config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `options.columnDateFormat` and `options.columnDateTimeFormat` were ignored
 
 ## [1.11.4] - 2021-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - `options.columnDateFormat` and `options.columnDateTimeFormat` were ignored
+- `options.storageIdentifier` was ignored if provided from server config
 
 ## [1.11.4] - 2021-02-22
 

--- a/projects/smart-table/src/lib/services/api.service.ts
+++ b/projects/smart-table/src/lib/services/api.service.ts
@@ -52,7 +52,7 @@ export class ApiService {
             ...config,
             options: {
               ...config.options,
-              storageIdentifier: this.storageIdentifier
+              storageIdentifier: config.options.storageIdentifier || this.storageIdentifier
             }
           };
         } else {

--- a/projects/smart-table/src/lib/services/configuration.service.ts
+++ b/projects/smart-table/src/lib/services/configuration.service.ts
@@ -65,7 +65,7 @@ export class ConfigurationService {
       map((config: SmartTableConfig) =>
         config.columns
           .sort(sortColumn)
-          .map(columnConfig => this.factory.createTableColumnFromConfig(columnConfig, columnTypes)))
+          .map(columnConfig => this.factory.createTableColumnFromConfig(columnConfig, columnTypes, config.options)))
     );
   }
 }


### PR DESCRIPTION
Fixed:
- columnDateTimeFormat was ignored if set in options, making it impossible to customize dateTime columns
- storageIdentifier was ignored if provided from server config, making it confusing under what id the config was saved in localstorage
